### PR TITLE
import View as {View} instead of default

### DIFF
--- a/packages/docs/src/03-Usage.svench/index.md
+++ b/packages/docs/src/03-Usage.svench/index.md
@@ -4,7 +4,7 @@
 
 ~~~svelte
 <script>
-  import View from 'svench'
+  import { View } from 'svench'
 </script>
 
 <View name="defaults" let:action knobs={{prop1: false}} let:knobs={{prop1}}>


### PR DESCRIPTION
... as this seems to be the behavior as of v0.2.0-14

(also, this new version of svench looks :fire:-amazing!)