### PR TITLE
provides the url when starting

### DIFF
--- a/packages/svench/cli/commands/vite/dev.js
+++ b/packages/svench/cli/commands/vite/dev.js
@@ -1,4 +1,5 @@
 import { loadVite, loadSvenchifiedConfig } from './util.js'
+import { Log } from '../../lib.js'
 
 export default async (info, cliOptions) => {
   const mode = 'development'
@@ -13,6 +14,8 @@ export default async (info, cliOptions) => {
   )
 
   const server = await createServer(finalConfig)
+  
+  Log.warn( 'Svench ready and listening at http://localhost:%s', server.config.server.port )
 
   await server.listen()
 }


### PR DESCRIPTION
The fix is probably not exactly at the right place, but yeah, I just spend waaaay too much time wondering why svench was hanging on startup, before realizing that it was not, and was waiting for me at :4242. Duh!